### PR TITLE
Supply Roact through the storybook

### DIFF
--- a/example/Button.story.lua
+++ b/example/Button.story.lua
@@ -3,7 +3,6 @@ local Button = require(script.Parent.Button)
 
 return {
 	summary = "A generic button component that can be used anywhere",
-	roact = Roact,
 	story = Roact.createElement(Button, {
 		text = "Click me",
 		onActivated = function()

--- a/example/ButtonWithControls.story.lua
+++ b/example/ButtonWithControls.story.lua
@@ -3,7 +3,6 @@ local ButtonWithControls = require(script.Parent.ButtonWithControls)
 
 return {
 	summary = "A generic button component that can be used anywhere",
-	roact = Roact,
 	controls = {
 		isDisabled = false,
 	},

--- a/example/Counter.story.lua
+++ b/example/Counter.story.lua
@@ -7,7 +7,6 @@ return {
 		Increment = 1,
 		["Wait time"] = 1,
 	},
-	roact = Roact,
 	story = function(props)
 		return Roact.createElement(Counter, {
 			increment = props.controls["Increment"],

--- a/example/Example.storybook.lua
+++ b/example/Example.storybook.lua
@@ -1,4 +1,7 @@
+local Roact = require(script.Parent.Parent.Roact)
+
 return {
+	roact = Roact,
 	storyRoots = {
 		script.Parent,
 	},

--- a/src/Components/App.lua
+++ b/src/Components/App.lua
@@ -15,6 +15,7 @@ local function App(_props, hooks: any)
 	local theme = useTheme(hooks)
 	local storybooks = useStorybooks(hooks, game, loader)
 	local story, selectStory = hooks.useState(nil)
+	local storybook, selectStorybook = hooks.useState(nil)
 	local isSidebarExpanded, setIsSidebarExpanded = hooks.useState(true)
 
 	local toggleSidebar = hooks.useCallback(function()
@@ -38,6 +39,7 @@ local function App(_props, hooks: any)
 			layoutOrder = 1,
 			storybooks = storybooks,
 			selectStory = selectStory,
+			selectStorybook = selectStorybook,
 			isExpanded = isSidebarExpanded,
 			width = SIDEBAR_WIDTH,
 			onToggleActivated = toggleSidebar,
@@ -50,6 +52,7 @@ local function App(_props, hooks: any)
 		}, {
 			StoryView = story and Roact.createElement(StoryView, {
 				story = story,
+				storybook = storybook,
 				loader = loader,
 			}),
 

--- a/src/Components/App.story.lua
+++ b/src/Components/App.story.lua
@@ -4,6 +4,5 @@ local App = require(script.Parent.App)
 return {
 	summary = "The main component that handles the entire plugin",
 	controls = {},
-	roact = Roact,
 	story = Roact.createElement(App),
 }

--- a/src/Components/Button.story.lua
+++ b/src/Components/Button.story.lua
@@ -5,7 +5,6 @@ local Button = require(script.Parent.Button)
 local PADDING = UDim.new(0, 16)
 
 return {
-	roact = Roact,
 	story = Roact.createFragment({
 		Layout = Roact.createElement("UIListLayout", {
 			SortOrder = Enum.SortOrder.LayoutOrder,

--- a/src/Components/Checkbox.story.lua
+++ b/src/Components/Checkbox.story.lua
@@ -19,6 +19,5 @@ end
 Story = RoactHooks.new(Roact)(Story)
 
 return {
-	roact = Roact,
 	story = Roact.createElement(Story),
 }

--- a/src/Components/NoStorySelected.story.lua
+++ b/src/Components/NoStorySelected.story.lua
@@ -2,6 +2,5 @@ local Roact = require(script.Parent.Parent.Packages.Roact)
 local NoStorySelected = require(script.Parent.NoStorySelected)
 
 return {
-	roact = Roact,
 	story = Roact.createElement(NoStorySelected),
 }

--- a/src/Components/Panel.story.lua
+++ b/src/Components/Panel.story.lua
@@ -4,7 +4,6 @@ local styles = require(script.Parent.Parent.styles)
 local Panel = require(script.Parent.Panel)
 
 return {
-	roact = Roact,
 	story = Roact.createElement("Frame", {
 		Size = UDim2.fromScale(0.5, 1),
 		BackgroundTransparency = 1,

--- a/src/Components/Sample.story.lua
+++ b/src/Components/Sample.story.lua
@@ -6,7 +6,6 @@ return {
 		["Message content"] = "Hello, World!",
 		["Use alt color"] = false,
 	},
-	roact = Roact,
 	story = function(props)
 		local color = if props.controls["Use alt color"]
 			then Color3.fromRGB(68, 32, 228)

--- a/src/Components/Sidebar.lua
+++ b/src/Components/Sidebar.lua
@@ -15,6 +15,7 @@ type Props = {
 	width: NumberRange,
 	storybooks: { types.Storybook },
 	selectStory: (types.Story) -> (),
+	selectStorybook: (types.Storybook) -> (),
 	layoutOrder: number?,
 	onToggleActivated: (() -> ())?,
 }
@@ -26,6 +27,7 @@ local function Sidebar(props: Props, hooks: any)
 
 	local onNodeActivated = hooks.useCallback(function(node: TreeList.Node)
 		if node.instance and node.name:match(constants.STORY_NAME_PATTERN) then
+			props.selectStorybook(node.storybook)
 			props.selectStory(node.instance)
 			setActiveNode(node)
 		end

--- a/src/Components/Sidebar.story.lua
+++ b/src/Components/Sidebar.story.lua
@@ -27,6 +27,5 @@ Story = RoactHooks.new(Roact)(Story)
 
 return {
 	summary = "The sidebar that displays all the available stories for the current Storybook",
-	roact = Roact,
 	story = Roact.createElement(Story),
 }

--- a/src/Components/SidebarToggle.story.lua
+++ b/src/Components/SidebarToggle.story.lua
@@ -20,6 +20,5 @@ end
 Story = RoactHooks.new(Roact)(Story)
 
 return {
-	roact = Roact,
 	story = Roact.createElement(Story),
 }

--- a/src/Components/StoryControl.story.lua
+++ b/src/Components/StoryControl.story.lua
@@ -7,7 +7,6 @@ end
 
 return {
 	summary = "Several of these components get created based off the controls specified for a story",
-	roact = Roact,
 	story = Roact.createFragment({
 		Layout = Roact.createElement("UIListLayout", {
 			Padding = UDim.new(0, 16),

--- a/src/Components/StoryError.story.lua
+++ b/src/Components/StoryError.story.lua
@@ -3,7 +3,6 @@ local StoryError = require(script.Parent.StoryError)
 
 return {
 	summary = "Displays the error message when something goes wrong in a story",
-	roact = Roact,
 	story = Roact.createElement(StoryError, {
 		message = [[
 14:27:55.439  PluginDebugService.user_flipbook.rbxm.flipbook.Components.App:11: oops  -  Edit - App:11

--- a/src/Components/StoryMeta.story.lua
+++ b/src/Components/StoryMeta.story.lua
@@ -2,7 +2,6 @@ local Roact = require(script.Parent.Parent.Packages.Roact)
 local StoryMeta = require(script.Parent.StoryMeta)
 
 return {
-	roact = Roact,
 	story = Roact.createElement(StoryMeta, {
 		story = {
 			name = "Sample.story",

--- a/src/Components/StoryView.lua
+++ b/src/Components/StoryView.lua
@@ -7,6 +7,7 @@ local RoactHooks = require(script.Parent.Parent.Packages.RoactHooks)
 local useStory = require(script.Parent.Parent.Hooks.useStory)
 local getStoryElement = require(script.Parent.Parent.Modules.getStoryElement)
 local enums = require(script.Parent.Parent.enums)
+local types = require(script.Parent.Parent.types)
 local styles = require(script.Parent.Parent.styles)
 local StoryMeta = require(script.Parent.StoryMeta)
 local StoryError = require(script.Parent.StoryError)
@@ -14,6 +15,7 @@ local StoryError = require(script.Parent.StoryError)
 type Props = {
 	story: ModuleScript,
 	loader: ModuleLoader.Class,
+	storybook: types.Storybook,
 }
 
 local function createViewportPreview(): ScreenGui
@@ -37,7 +39,7 @@ end
 local function StoryView(props: Props, hooks: any)
 	local storyParent = Roact.createRef()
 	local err, setErr = hooks.useState(nil)
-	local story, storyErr = useStory(hooks, props.story, props.loader)
+	local story, storyErr = useStory(hooks, props.story, props.storybook, props.loader)
 	local prevStory = usePrevious(hooks, story)
 	local controls, setControls = hooks.useState({})
 	local isUsingViewport, setIsUsingViewport = hooks.useState(false)

--- a/src/Components/StoryView.story.lua
+++ b/src/Components/StoryView.story.lua
@@ -2,9 +2,19 @@ local ModuleLoader = require(script.Parent.Parent.Packages.ModuleLoader)
 local Roact = require(script.Parent.Parent.Packages.Roact)
 local StoryView = require(script.Parent.StoryView)
 
-return {
-	story = Roact.createElement(StoryView, {
+local function Story()
+	local loader = ModuleLoader.new()
+	loader:cache(script.Parent.Parent.Packages.Roact, Roact)
+
+	local storybook = loader:require(script.Parent.Parent["init.storybook"])
+
+	return Roact.createElement(StoryView, {
 		story = script.Parent["Button.story"],
-		loader = ModuleLoader.new(),
-	}),
+		storybook = storybook,
+		loader = loader,
+	})
+end
+
+return {
+	story = Story,
 }

--- a/src/Components/StoryView.story.lua
+++ b/src/Components/StoryView.story.lua
@@ -2,7 +2,6 @@ local Roact = require(script.Parent.Parent.Packages.Roact)
 local StoryView = require(script.Parent.StoryView)
 
 return {
-	roact = Roact,
 	story = Roact.createElement(StoryView, {
 		story = script.Parent["Button.story"],
 	}),

--- a/src/Components/TreeList/init.story.lua
+++ b/src/Components/TreeList/init.story.lua
@@ -4,7 +4,6 @@ local TreeList = require(script.Parent)
 local types = require(script.Parent.types)
 
 return {
-	roact = Roact,
 	story = Roact.createElement(TreeList, {
 		onNodeActivated = function(node: types.Node)
 			print(node.name, "activated")

--- a/src/Hooks/useStory.lua
+++ b/src/Hooks/useStory.lua
@@ -2,7 +2,12 @@ local ModuleLoader = require(script.Parent.Parent.Packages.ModuleLoader)
 local types = require(script.Parent.Parent.types)
 local loadStoryModule = require(script.Parent.Parent.Modules.loadStoryModule)
 
-local function useStory(hooks: any, module: ModuleScript, loader: ModuleLoader.Class): types.Story?
+local function useStory(
+	hooks: any,
+	module: ModuleScript,
+	storybook: types.Storybook,
+	loader: ModuleLoader.Class
+): types.Story?
 	local state, setState = hooks.useState({
 		story = nil,
 		err = nil,
@@ -10,6 +15,8 @@ local function useStory(hooks: any, module: ModuleScript, loader: ModuleLoader.C
 
 	local loadStory = hooks.useCallback(function()
 		local story, err = loadStoryModule(loader, module)
+
+		story.roact = story.roact or storybook.roact
 
 		setState({
 			story = story,

--- a/src/Modules/createStoryNodes.lua
+++ b/src/Modules/createStoryNodes.lua
@@ -3,7 +3,7 @@ local assets = require(script.Parent.Parent.assets)
 local constants = require(script.Parent.Parent.constants)
 local types = require(script.Parent.Parent.types)
 
-local function addStoriesToNode(root: Instance, node: TreeList.Node)
+local function addStoriesToNode(root: Instance, node: TreeList.Node, storybook: types.Storybook)
 	for _, child in ipairs(root:GetChildren()) do
 		local nextNode = {
 			name = child.Name,
@@ -13,6 +13,7 @@ local function addStoriesToNode(root: Instance, node: TreeList.Node)
 
 		if child.Name:match(constants.STORY_NAME_PATTERN) then
 			nextNode.icon = assets.story
+			nextNode.storybook = storybook
 			table.insert(node.children, nextNode)
 		else
 			if #child:GetChildren() > 0 then
@@ -37,7 +38,7 @@ local function createStoryNodes(storybooks: { types.Storybook }): { TreeList.Nod
 		table.insert(nodes, node)
 
 		for _, root in ipairs(storybook.storyRoots) do
-			addStoriesToNode(root, node)
+			addStoriesToNode(root, node, storybook)
 		end
 	end
 

--- a/src/Modules/loadStoryModule.lua
+++ b/src/Modules/loadStoryModule.lua
@@ -10,8 +10,6 @@ local function loadStoryModule(loader: ModuleLoader.Class, module: ModuleScript)
 		return nil, "Did not receive a module to load"
 	end
 
-	loader:clear()
-
 	local success, result = pcall(function()
 		return loader:require(module)
 	end)


### PR DESCRIPTION
Currently each story must supply the Roact instance it is using. Instead, this will now be supplied through the storybook module

Closes #46 