### PR TITLE
Update README to include new sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,19 @@
 [![CI](https://github.com/vocksel/flipbook/actions/workflows/ci.yml/badge.svg)](https://github.com/vocksel/flipbook/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-website-brightgreen)](https://vocksel.github.io/flipbook)
 
-WIP WIP WIP
+With flipbook you can quickly iterate on Roact components in an isolated, sandboxed environment to streamline the process of creating reusable UI components.
+
+## Download
+
+You can install the latest version of flipbook from the [Roblox marketplace](https://www.roblox.com/library/8517129161).
 
 ## Documentation
 
-You can find the documentation [here](https://vocksel.github.io/flipbook).
+Learn how to use flipbook [here](https://vocksel.github.io/flipbook).
 
 ## Contributing
 
-See the [contributing guide](https://vocksel.github.io/flipbook/docs/contributing).
+Interested in contributing? Check out our [contributing guide](https://vocksel.github.io/flipbook/docs/contributing).
 
 ## License
 


### PR DESCRIPTION
# Problem

The README is currently missing information on installing the plugin, and is yet to have a blurb

# Solution

Added a Download section and propagated the "WIP WIP WIP" content with some copy from the documentation


