### PR TITLE
Display error for malformed stories

### DIFF
--- a/src/Components/StoryView.lua
+++ b/src/Components/StoryView.lua
@@ -24,7 +24,7 @@ type Props = {
 
 local function StoryView(props: Props, hooks: any)
 	local theme = useTheme(hooks)
-	local story = useStory(hooks, props.story, props.storybook, props.loader)
+	local story, storyErr = useStory(hooks, props.story, props.storybook, props.loader)
 	local zoom = useZoom(hooks, props.story)
 	local plugin = hooks.useContext(PluginContext.Context)
 
@@ -54,6 +54,26 @@ local function StoryView(props: Props, hooks: any)
 			onZoomIn = zoom.zoomIn,
 			onZoomOut = zoom.zoomOut,
 			onViewCode = viewCode,
+		}),
+
+		Error = storyErr and e("TextLabel", {
+			BackgroundTransparency = 1,
+			Font = theme.font,
+			LayoutOrder = 2,
+			Size = UDim2.fromScale(1, 1),
+			Text = storyErr,
+			TextColor3 = theme.text,
+			TextWrapped = true,
+			TextSize = theme.textSize,
+			TextXAlignment = Enum.TextXAlignment.Left,
+			TextYAlignment = Enum.TextYAlignment.Top,
+		}, {
+			Padding = e("UIPadding", {
+				PaddingTop = theme.padding,
+				PaddingRight = theme.padding,
+				PaddingBottom = theme.padding,
+				PaddingLeft = theme.padding,
+			}),
 		}),
 
 		Content = story and e("Frame", {

--- a/src/Hooks/useStory.lua
+++ b/src/Hooks/useStory.lua
@@ -12,7 +12,9 @@ local function useStory(hooks: any, module: ModuleScript, storybook: types.Story
 	local loadStory = hooks.useCallback(function()
 		local story, err = loadStoryModule(loader, module)
 
-		story.roact = if story.roact then story.roact else storybook.roact
+		if story and not story.roact then
+			story.roact = storybook.roact
+		end
 
 		setState({
 			story = story,

--- a/src/Story/loadStoryModule.lua
+++ b/src/Story/loadStoryModule.lua
@@ -7,7 +7,7 @@ local isStory = require(flipbook.Story.isStory)
 local isHoarcekatStory = require(flipbook.Story.isHoarcekatStory)
 
 local Errors = {
-	MalformedStory = "Story is malformed. Check the source of %q and make sure it has the correct properties",
+	MalformedStory = "Story is malformed. Check the source of %q and make sure its properties are correct",
 	Generic = "Failed to load story %q. Error: %s",
 }
 

--- a/src/Story/loadStoryModule.lua
+++ b/src/Story/loadStoryModule.lua
@@ -6,6 +6,11 @@ local types = require(script.Parent.Parent.types)
 local isStory = require(flipbook.Story.isStory)
 local isHoarcekatStory = require(flipbook.Story.isHoarcekatStory)
 
+local Errors = {
+	MalformedStory = "Story is malformed. Check the source of %q and make sure it has the correct properties",
+	Generic = "Failed to load story %q. Error: %s",
+}
+
 local function loadStoryModule(loader: any, module: ModuleScript): (types.Story?, string?)
 	if not module then
 		return nil, "Did not receive a module to load"
@@ -16,7 +21,7 @@ local function loadStoryModule(loader: any, module: ModuleScript): (types.Story?
 	end)
 
 	if not success then
-		return nil, result
+		return nil, Errors.Generic:format(module:GetFullName(), tostring(result))
 	end
 
 	if isStory(result) then
@@ -35,7 +40,7 @@ local function loadStoryModule(loader: any, module: ModuleScript): (types.Story?
 
 		return story, nil
 	else
-		return nil, ("Could not select story %s"):format(module:GetFullName())
+		return nil, Errors.MalformedStory:format(module:GetFullName())
 	end
 end
 


### PR DESCRIPTION
# Problem

When a story is malformed (for example, missing the `story` key) opening it causes flipbook to throw an error and cease working

# Solution

To fix this, we now guard against indexing `story.roact` since there can be cases where that property doesn't exist yet. And we're also now handling the error message when a story fails to load and display it to the user. This should give some helpful context about what went wrong

Closes #125

# Checklist

- [ ] Ran `./bin/test.sh` locally before merging
