### PR TITLE
Listen for new storybooks from name changes

### DIFF
--- a/src/Hooks/useDescendants.lua
+++ b/src/Hooks/useDescendants.lua
@@ -1,0 +1,58 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local Llama = require(flipbook.Packages.Llama)
+
+local function useDescendants(hooks: any, parent: Instance, predicate: (descendant: Instance) -> boolean): { Instance }
+	local descendants: { Instance }, setDescendants = hooks.useState({})
+
+	local onDescendantChanged = hooks.useCallback(function(descendant: Instance)
+		local exists = table.find(descendants, descendant)
+		if predicate(descendant) then
+			if exists then
+				-- Force a re-render. Nothing about the state changed, but the
+				-- module uses a new name now
+				setDescendants(table.clone(descendants))
+			else
+				setDescendants(Llama.List.append(descendants, descendant))
+			end
+		else
+			if exists then
+				setDescendants(Llama.List.filter(descendants, function(other: Instance)
+					return descendant ~= other
+				end))
+			end
+		end
+	end, { predicate, descendants, setDescendants })
+
+	-- Setup the initial list of descendants for the current parent
+	hooks.useEffect(function()
+		setDescendants(Llama.List.filter(parent:GetDescendants(), predicate))
+	end, { parent })
+
+	hooks.useEffect(function()
+		local connections = {
+			parent.DescendantAdded:Connect(onDescendantChanged),
+			parent.DescendantRemoving:Connect(onDescendantChanged),
+		}
+
+		-- Listen for name changes and update the list of descendants
+		for _, descendant in parent:GetDescendants() do
+			table.insert(
+				connections,
+				descendant:GetPropertyChangedSignal("Name"):Connect(function()
+					onDescendantChanged(descendant)
+				end)
+			)
+		end
+
+		return function()
+			for _, conn in connections do
+				conn:Disconnect()
+			end
+		end
+	end, { parent, onDescendantChanged })
+
+	return descendants
+end
+
+return useDescendants

--- a/src/Hooks/useStorybooks.lua
+++ b/src/Hooks/useStorybooks.lua
@@ -81,7 +81,6 @@ local function useStorybooks(hooks: any, parent: Instance, loader: any)
 			added:Disconnect()
 			removing:Disconnect()
 
-			print(nameChangeListeners.value)
 			for _, conn in ipairs(nameChangeListeners.value) do
 				conn:Disconnect()
 			end


### PR DESCRIPTION
# Problem

For user's that work in Studio, creating a new ModuleScript and renaming it to include `.storybook` does not result in the storybook being picked up by flipbook

# Solution

To fix this, any ModuleScript added to the DataModel has its Name property listened to for changes and the storybooks are reloaded if a module's name is updated to include `.storybook`

Closes #124

# Checklist

- [x] Ran `./bin/test.sh` locally before merging
