### PR TITLE
Fix internal storybook error

### DIFF
--- a/src/Hooks/useStorybooks.lua
+++ b/src/Hooks/useStorybooks.lua
@@ -29,16 +29,22 @@ local function useStorybooks(hooks: any, parent: Instance, loader: any)
 				continue
 			end
 
-			local success, result = pcall(function()
+			local wasRequired, result = pcall(function()
 				return loader:require(module)
 			end)
 
-			if success and isStorybook(result) then
-				result.name = if result.name
-					then result.name
-					else module.Name:gsub(constants.STORYBOOK_NAME_PATTERN, "")
+			if wasRequired then
+				local success, message = isStorybook(result)
 
-				table.insert(newStorybooks, result)
+				if success then
+					result.name = if result.name
+						then result.name
+						else module.Name:gsub(constants.STORYBOOK_NAME_PATTERN, "")
+
+					table.insert(newStorybooks, result)
+				else
+					warn(("Failed to load storybook %s. Error: %s"):format(module:GetFullName(), message))
+				end
 			end
 		end
 

--- a/src/init.storybook.lua
+++ b/src/init.storybook.lua
@@ -2,7 +2,6 @@ local Roact = require(script.Parent.Packages.Roact)
 
 return {
 	name = script.Parent.Name,
-	summary = "The one (and only) storybook for flipbook",
 	storyRoots = {
 		script.Parent.Components,
 	},


### PR DESCRIPTION
# Problem

I discovered that the internal storybook was not being loaded in the sidebar even with `IS_DEV_MODE` set to `true`

# Solution

Turns out this was because the `isStorybook` check was failing because the storybook had the `summary` field which isn't supposed to be there. I've removed that field and also added an error message to ensure this gets caught earlier next time

# Checklist

- [ ] Ran `./bin/test.sh` locally before merging
