### PR TITLE
Fix VSCode prompting to scan for each task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,22 +6,26 @@
     {
       "label": "Build (MacOS)",
       "type": "shell",
-      "command": "rojo build -o ~/Documents/Roblox/Plugins/flipbook.rbxm"
+      "command": "rojo build -o ~/Documents/Roblox/Plugins/flipbook.rbxm",
+      "problemMatcher": []
     },
     {
       "label": "Build and watch (MacOS)",
       "type": "shell",
-      "command": "rojo build -o ~/Documents/Roblox/Plugins/flipbook.rbxm --watch"
+      "command": "rojo build -o ~/Documents/Roblox/Plugins/flipbook.rbxm --watch",
+      "problemMatcher": []
     },
     {
       "label": "Build (Windows)",
       "type": "shell",
-      "command": "rojo build -o $LOCALAPPDATA/Roblox/Plugins/flipbook.rbxm"
+      "command": "rojo build -o $LOCALAPPDATA/Roblox/Plugins/flipbook.rbxm",
+      "problemMatcher": []
     },
     {
       "label": "Build and watch (Windows)",
       "type": "shell",
-      "command": "rojo build -o $LOCALAPPDATA/Roblox/Plugins/flipbook.rbxm --watch"
+      "command": "rojo build -o $LOCALAPPDATA/Roblox/Plugins/flipbook.rbxm --watch",
+      "problemMatcher": []
     }
   ]
 }


### PR DESCRIPTION
# Problem

When running one of our included tasks, VSCode prompts to scan the output

# Solution

To fix this I've added a `problemMatcher` array to each task which bypasses the prompts

