### PR TITLE
Allow panels to be resized

### DIFF
--- a/src/Components/App.lua
+++ b/src/Components/App.lua
@@ -1,25 +1,38 @@
 local flipbook = script:FindFirstAncestor("flipbook")
 
 local ModuleLoader = require(flipbook.Packages.ModuleLoader)
+local Sift = require(flipbook.Packages.Sift)
 local Roact = require(flipbook.Packages.Roact)
 local hook = require(flipbook.hook)
 local useStorybooks = require(flipbook.Hooks.useStorybooks)
 local useTheme = require(flipbook.Hooks.useTheme)
 local PluginContext = require(flipbook.Plugin.PluginContext)
+local ResizablePanel = require(script.Parent.ResizablePanel)
 local Canvas = require(script.Parent.Canvas)
 local Sidebar = require(script.Parent.Sidebar)
 
 local loader = ModuleLoader.new()
 
-export type Props = {
+local defaultProps = {
+	initialsSidebarWidth = 260, -- px
+	minSidebarWidth = 180, -- px
+	maxSidebarWidth = 500, -- px
+}
+
+export type Props = typeof(defaultProps) & {
 	plugin: Plugin,
 }
 
+type InternalProps = Props & typeof(defaultProps)
+
 local function App(props: Props, hooks: any)
+	props = Sift.Dictionary.merge(defaultProps, props)
+
 	local theme = useTheme(hooks)
 	local storybooks = useStorybooks(hooks, game, loader)
 	local story, setStory = hooks.useState(nil)
 	local storybook, selectStorybook = hooks.useState(nil)
+	local sidebarWidth, setSidebarWidth = hooks.useState(props.initialsSidebarWidth)
 
 	local selectStory = hooks.useCallback(function(newStory: ModuleScript)
 		setStory(function(prevStory: ModuleScript)
@@ -27,31 +40,47 @@ local function App(props: Props, hooks: any)
 		end)
 	end, { setStory })
 
+	local onSidebarResized = hooks.useCallback(function(newSize: Vector2)
+		setSidebarWidth(newSize.X)
+	end, {})
+
 	return Roact.createElement(PluginContext.Provider, {
 		plugin = props.plugin,
 	}, {
-		Roact.createElement("Frame", {
+		Background = Roact.createElement("Frame", {
 			BackgroundColor3 = theme.background,
 			Size = UDim2.fromScale(1, 1),
 		}, {
-			UIListLayout = Roact.createElement("UIListLayout", {
+			Layout = Roact.createElement("UIListLayout", {
 				FillDirection = Enum.FillDirection.Horizontal,
 				SortOrder = Enum.SortOrder.LayoutOrder,
 				VerticalAlignment = Enum.VerticalAlignment.Center,
 			}),
 
-			Sidebar = Roact.createElement(Sidebar, {
+			SidebarWrapper = Roact.createElement(ResizablePanel, {
 				layoutOrder = 1,
-				selectStory = selectStory,
-				selectStorybook = selectStorybook,
-				storybooks = storybooks,
+				initialSize = UDim2.new(0, props.initialsSidebarWidth, 1, 0),
+				dragHandles = { "Right" },
+				minSize = Vector2.new(props.minSidebarWidth, 0),
+				maxSize = Vector2.new(props.maxSidebarWidth, math.huge),
+				onResize = onSidebarResized,
+			}, {
+				Sidebar = Roact.createElement(Sidebar, {
+					selectStory = selectStory,
+					selectStorybook = selectStorybook,
+					storybooks = storybooks,
+				}),
 			}),
 
-			Canvas = Roact.createElement(Canvas, {
-				layoutOrder = 2,
-				loader = loader,
-				story = story,
-				storybook = storybook,
+			MainWrapper = Roact.createElement("Frame", {
+				LayoutOrder = 2,
+				Size = UDim2.fromScale(1, 1) - UDim2.fromOffset(sidebarWidth, 0),
+			}, {
+				Canvas = Roact.createElement(Canvas, {
+					loader = loader,
+					story = story,
+					storybook = storybook,
+				}),
 			}),
 		}),
 	})

--- a/src/Components/App.lua
+++ b/src/Components/App.lua
@@ -1,9 +1,9 @@
 local flipbook = script:FindFirstAncestor("flipbook")
 
 local ModuleLoader = require(flipbook.Packages.ModuleLoader)
-local Sift = require(flipbook.Packages.Sift)
 local Roact = require(flipbook.Packages.Roact)
 local hook = require(flipbook.hook)
+local constants = require(flipbook.constants)
 local useStorybooks = require(flipbook.Hooks.useStorybooks)
 local useTheme = require(flipbook.Hooks.useTheme)
 local PluginContext = require(flipbook.Plugin.PluginContext)
@@ -13,26 +13,16 @@ local Sidebar = require(script.Parent.Sidebar)
 
 local loader = ModuleLoader.new()
 
-local defaultProps = {
-	initialsSidebarWidth = 260, -- px
-	minSidebarWidth = 180, -- px
-	maxSidebarWidth = 500, -- px
-}
-
-export type Props = typeof(defaultProps) & {
+export type Props = {
 	plugin: Plugin,
 }
 
-type InternalProps = Props & typeof(defaultProps)
-
 local function App(props: Props, hooks: any)
-	props = Sift.Dictionary.merge(defaultProps, props)
-
 	local theme = useTheme(hooks)
 	local storybooks = useStorybooks(hooks, game, loader)
 	local story, setStory = hooks.useState(nil)
 	local storybook, selectStorybook = hooks.useState(nil)
-	local sidebarWidth, setSidebarWidth = hooks.useState(props.initialsSidebarWidth)
+	local sidebarWidth, setSidebarWidth = hooks.useState(constants.SIDEBAR_INITIAL_WIDTH)
 
 	local selectStory = hooks.useCallback(function(newStory: ModuleScript)
 		setStory(function(prevStory: ModuleScript)
@@ -59,10 +49,10 @@ local function App(props: Props, hooks: any)
 
 			SidebarWrapper = Roact.createElement(ResizablePanel, {
 				layoutOrder = 1,
-				initialSize = UDim2.new(0, props.initialsSidebarWidth, 1, 0),
+				initialSize = UDim2.new(0, constants.SIDEBAR_INITIAL_WIDTH, 1, 0),
 				dragHandles = { "Right" },
-				minSize = Vector2.new(props.minSidebarWidth, 0),
-				maxSize = Vector2.new(props.maxSidebarWidth, math.huge),
+				minSize = Vector2.new(constants.SIDEBAR_MIN_WIDTH, 0),
+				maxSize = Vector2.new(constants.SIDEBAR_MAX_WIDTH, math.huge),
 				onResize = onSidebarResized,
 			}, {
 				Sidebar = Roact.createElement(Sidebar, {

--- a/src/Components/Canvas.lua
+++ b/src/Components/Canvas.lua
@@ -23,7 +23,7 @@ local function Canvas(props: Props, hooks: any)
 		BackgroundColor3 = theme.canvas,
 		BorderSizePixel = 0,
 		LayoutOrder = props.layoutOrder,
-		Size = UDim2.new(1, -267, 1, 0),
+		Size = UDim2.fromScale(1, 1),
 	}, {
 		Divider = e("Frame", {
 			AnchorPoint = Vector2.new(1, 0),

--- a/src/Components/ComponentTree/Component/Directory.lua
+++ b/src/Components/ComponentTree/Component/Directory.lua
@@ -51,7 +51,7 @@ local function Directory(props: Props, hooks: any)
 
 		UIPadding = e("UIPadding", {
 			PaddingBottom = theme.padding,
-			PaddingLeft = UDim.new(0, theme.paddingSmall.Offset * (props.indent + 1)),
+			PaddingLeft = theme.paddingSmall + UDim.new(0, theme.padding.Offset * props.indent),
 			PaddingRight = theme.paddingSmall,
 			PaddingTop = theme.padding,
 		}),

--- a/src/Components/ComponentTree/Component/Story.lua
+++ b/src/Components/ComponentTree/Component/Story.lua
@@ -51,7 +51,7 @@ local function Story(props: Props, hooks: any)
 
 		UIPadding = e("UIPadding", {
 			PaddingBottom = theme.padding,
-			PaddingLeft = UDim.new(0, theme.paddingSmall.Offset * (props.indent + 1)),
+			PaddingLeft = theme.paddingSmall + UDim.new(0, theme.padding.Offset * props.indent),
 			PaddingRight = theme.paddingSmall,
 			PaddingTop = theme.padding,
 		}),

--- a/src/Components/DragHandle.lua
+++ b/src/Components/DragHandle.lua
@@ -1,0 +1,109 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local RunService = game:GetService("RunService")
+
+local Sift = require(flipbook.Packages.Sift)
+local Roact = require(flipbook.Packages.Roact)
+local hook = require(flipbook.hook)
+local types = require(script.Parent.Parent.types)
+
+local defaultProps = {
+	size = 8, -- px
+	hoverIcon = "",
+}
+
+export type Props = typeof(defaultProps) & {
+	handle: types.DragHandle,
+	onDrag: (delta: Vector2) -> (),
+	onDragEnd: (() -> ())?,
+}
+
+local function DragHandle(props: Props, hooks: any)
+	props = Sift.Dictionary.merge(defaultProps, props)
+
+	local isDragging, setIsDragging = hooks.useState(false)
+	local mouseInput: InputObject, setMouseInput = hooks.useState(nil)
+
+	local getHandleProperties = hooks.useCallback(function()
+		local size: UDim2
+		local position: UDim2
+		local anchorPoint: Vector2
+
+		if props.handle == "Right" or props.handle == "Left" then
+			size = UDim2.new(0, props.size, 1, 0)
+
+			if props.handle == "Right" then
+				position = UDim2.fromScale(1, 0)
+				anchorPoint = Vector2.new(0.5, 0)
+			else
+				position = UDim2.fromScale(0, 0)
+				anchorPoint = Vector2.new(0, 0)
+			end
+		elseif props.handle == "Top" or props.handle == "Bottom" then
+			size = UDim2.new(1, 0, 0, props.size)
+
+			if props.handle == "Bottom" then
+				position = UDim2.fromScale(0, 1)
+				anchorPoint = Vector2.new(0, 0.5)
+			else
+				position = UDim2.fromScale(0, 0)
+				anchorPoint = Vector2.new(0, 0)
+			end
+		end
+
+		return size, position, anchorPoint
+	end, { props.handle, props.size })
+
+	local onInputBegan = hooks.useCallback(function(_rbx, input: InputObject)
+		if input.UserInputType == Enum.UserInputType.MouseButton1 then
+			setIsDragging(true)
+		elseif input.UserInputType == Enum.UserInputType.MouseMovement then
+			setMouseInput(input)
+		end
+	end, { isDragging })
+
+	local onInputEnded = hooks.useCallback(function(_rbx, input: InputObject)
+		if input.UserInputType == Enum.UserInputType.MouseButton1 then
+			setIsDragging(false)
+			setMouseInput(nil)
+
+			if props.onDragEnd then
+				props.onDragEnd()
+			end
+		end
+	end, { props.onDragEnd })
+
+	local size, position, anchorPoint = getHandleProperties()
+
+	hooks.useEffect(function()
+		if mouseInput and isDragging then
+			local lastPosition = mouseInput.Position
+			local conn = RunService.Heartbeat:Connect(function()
+				local delta = mouseInput.Position - lastPosition
+
+				if props.onDrag and delta ~= Vector3.zero then
+					props.onDrag(Vector2.new(delta.X, delta.Y))
+				end
+
+				lastPosition = mouseInput.Position
+			end)
+
+			return function()
+				conn:Disconnect()
+			end
+		else
+			return nil
+		end
+	end, { mouseInput, isDragging })
+
+	return Roact.createElement("ImageButton", {
+		Size = size,
+		Position = position,
+		AnchorPoint = anchorPoint,
+		-- BackgroundTransparency = 1,
+		[Roact.Event.InputBegan] = onInputBegan,
+		[Roact.Event.InputEnded] = onInputEnded,
+	})
+end
+
+return hook(DragHandle)

--- a/src/Components/DragHandle.lua
+++ b/src/Components/DragHandle.lua
@@ -100,7 +100,7 @@ local function DragHandle(props: Props, hooks: any)
 		Size = size,
 		Position = position,
 		AnchorPoint = anchorPoint,
-		-- BackgroundTransparency = 1,
+		BackgroundTransparency = 1,
 		[Roact.Event.InputBegan] = onInputBegan,
 		[Roact.Event.InputEnded] = onInputEnded,
 	})

--- a/src/Components/ResizablePanel.lua
+++ b/src/Components/ResizablePanel.lua
@@ -52,7 +52,7 @@ local function ResizablePanel(props: Props, hooks: any)
 	end, { props.minSize, props.maxSize })
 
 	hooks.useEffect(function()
-		if props.onResize then
+		if clampedAbsoluteSize and props.onResize then
 			props.onResize(clampedAbsoluteSize)
 		end
 	end, { clampedAbsoluteSize })
@@ -74,10 +74,11 @@ local function ResizablePanel(props: Props, hooks: any)
 	end
 
 	return Roact.createElement("Frame", {
+		LayoutOrder = props.layoutOrder,
 		Size = if clampedAbsoluteSize
 			then UDim2.fromOffset(clampedAbsoluteSize.X, clampedAbsoluteSize.Y)
 			else props.initialSize,
-		BackgroundTransparency = 1,
+		-- BackgroundTransparency = 1,
 		[Roact.Change.AbsoluteSize] = onAbsoluteSizeChanged,
 	}, {
 		DragHandles = Roact.createFragment(dragHandles),

--- a/src/Components/ResizablePanel.lua
+++ b/src/Components/ResizablePanel.lua
@@ -39,7 +39,7 @@ local function ResizablePanel(props: Props, hooks: any)
 	local onHandleDragged = hooks.useCallback(function(handle: types.DragHandle, delta: Vector2)
 		setAbsoluteSize(function(prev: Vector2)
 			local x = prev.X + delta.X
-			local y = prev.Y + delta.Y
+			local y = prev.Y - delta.Y
 
 			if handle == "Top" or handle == "Bottom" then
 				x = prev.X
@@ -78,12 +78,15 @@ local function ResizablePanel(props: Props, hooks: any)
 		Size = if clampedAbsoluteSize
 			then UDim2.fromOffset(clampedAbsoluteSize.X, clampedAbsoluteSize.Y)
 			else props.initialSize,
-		-- BackgroundTransparency = 1,
+		BackgroundTransparency = 1,
 		[Roact.Change.AbsoluteSize] = onAbsoluteSizeChanged,
 	}, {
 		DragHandles = Roact.createFragment(dragHandles),
 
-		Children = Roact.createFragment((props :: any)[Roact.Children]),
+		Children = Roact.createElement("Frame", {
+			BackgroundTransparency = 1,
+			Size = UDim2.fromScale(1, 1),
+		}, (props :: any)[Roact.Children]),
 	})
 end
 

--- a/src/Components/ResizablePanel.lua
+++ b/src/Components/ResizablePanel.lua
@@ -7,7 +7,6 @@ local DragHandle = require(flipbook.Components.DragHandle)
 local types = require(script.Parent.Parent.types)
 
 local defaultProps = {
-	hoverIcon = "",
 	dragHandleSize = 8, -- px
 	minSize = Vector2.new(0, 0),
 	maxSize = Vector2.new(math.huge, math.huge),
@@ -17,6 +16,8 @@ export type Props = typeof(defaultProps) & {
 	initialSize: UDim2,
 	layoutOrder: number?,
 	dragHandles: { types.DragHandle }?,
+	hoverIconX: string?,
+	hoverIconY: string?,
 	onResize: ((newSize: Vector2) -> ())?,
 }
 
@@ -62,7 +63,8 @@ local function ResizablePanel(props: Props, hooks: any)
 		for _, handle in props.dragHandles do
 			dragHandles[handle] = Roact.createElement(DragHandle, {
 				handle = handle,
-				hoverIcon = props.hoverIcon,
+				hoverIconX = props.hoverIconX,
+				hoverIconY = props.hoverIconY,
 				onDrag = function(delta: Vector2)
 					onHandleDragged(handle, delta)
 				end,

--- a/src/Components/ResizablePanel.lua
+++ b/src/Components/ResizablePanel.lua
@@ -1,0 +1,89 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local Sift = require(flipbook.Packages.Sift)
+local Roact = require(flipbook.Packages.Roact)
+local hook = require(flipbook.hook)
+local DragHandle = require(flipbook.Components.DragHandle)
+local types = require(script.Parent.Parent.types)
+
+local defaultProps = {
+	hoverIcon = "",
+	dragHandleSize = 8, -- px
+	minSize = Vector2.new(0, 0),
+	maxSize = Vector2.new(math.huge, math.huge),
+}
+
+export type Props = typeof(defaultProps) & {
+	initialSize: UDim2,
+	layoutOrder: number?,
+	dragHandles: { types.DragHandle }?,
+	onResize: ((newSize: Vector2) -> ())?,
+}
+
+local function ResizablePanel(props: Props, hooks: any)
+	props = Sift.Dictionary.merge(defaultProps, props)
+
+	local absoluteSize, setAbsoluteSize = hooks.useState(nil)
+
+	local clampedAbsoluteSize = if absoluteSize
+		then Vector2.new(
+			math.clamp(absoluteSize.X, props.minSize.X, props.maxSize.X),
+			math.clamp(absoluteSize.Y, props.minSize.Y, props.maxSize.Y)
+		)
+		else nil
+
+	local onAbsoluteSizeChanged = hooks.useCallback(function(rbx: Frame)
+		setAbsoluteSize(rbx.AbsoluteSize)
+	end, {})
+
+	local onHandleDragged = hooks.useCallback(function(handle: types.DragHandle, delta: Vector2)
+		setAbsoluteSize(function(prev: Vector2)
+			local x = prev.X + delta.X
+			local y = prev.Y + delta.Y
+
+			if handle == "Top" or handle == "Bottom" then
+				x = prev.X
+			elseif handle == "Right" or handle == "Left" then
+				y = prev.Y
+			end
+
+			return Vector2.new(x, y)
+		end)
+	end, { props.minSize, props.maxSize })
+
+	hooks.useEffect(function()
+		if props.onResize then
+			props.onResize(clampedAbsoluteSize)
+		end
+	end, { clampedAbsoluteSize })
+
+	local dragHandles = {}
+	if props.dragHandles then
+		for _, handle in props.dragHandles do
+			dragHandles[handle] = Roact.createElement(DragHandle, {
+				handle = handle,
+				hoverIcon = props.hoverIcon,
+				onDrag = function(delta: Vector2)
+					onHandleDragged(handle, delta)
+				end,
+				onDragEnd = function()
+					setAbsoluteSize(clampedAbsoluteSize)
+				end,
+			})
+		end
+	end
+
+	return Roact.createElement("Frame", {
+		Size = if clampedAbsoluteSize
+			then UDim2.fromOffset(clampedAbsoluteSize.X, clampedAbsoluteSize.Y)
+			else props.initialSize,
+		BackgroundTransparency = 1,
+		[Roact.Change.AbsoluteSize] = onAbsoluteSizeChanged,
+	}, {
+		DragHandles = Roact.createFragment(dragHandles),
+
+		Children = Roact.createFragment((props :: any)[Roact.Children]),
+	})
+end
+
+return hook(ResizablePanel)

--- a/src/Components/ResizablePanel.story.lua
+++ b/src/Components/ResizablePanel.story.lua
@@ -21,7 +21,7 @@ return {
 			initialSize = UDim2.fromOffset(props.controls.maxWidth - props.controls.minWidth, 300),
 			maxSize = Vector2.new(props.controls.maxWidth, props.controls.maxHeight),
 			minSize = Vector2.new(props.controls.minWidth, props.controls.minHeight),
-			dragHandles = { "Right" },
+			dragHandles = { "Right", "Bottom" },
 		}, {
 			Content = Roact.createElement("Frame", {
 				Size = UDim2.fromScale(1, 1),

--- a/src/Components/ResizablePanel.story.lua
+++ b/src/Components/ResizablePanel.story.lua
@@ -1,0 +1,31 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local Roact = require(flipbook.Packages.Roact)
+local ResizablePanel = require(script.Parent.ResizablePanel)
+
+local controls = {
+	minWidth = 200,
+	maxWidth = 500,
+	minHeight = 200,
+	maxHeight = 500,
+}
+
+type Props = {
+	controls: typeof(controls),
+}
+
+return {
+	controls = controls,
+	story = function(props)
+		return Roact.createElement(ResizablePanel, {
+			initialSize = UDim2.fromOffset(props.controls.maxWidth - props.controls.minWidth, 300),
+			maxSize = Vector2.new(props.controls.maxWidth, props.controls.maxHeight),
+			minSize = Vector2.new(props.controls.minWidth, props.controls.minHeight),
+			dragHandles = { "Right" },
+		}, {
+			Content = Roact.createElement("Frame", {
+				Size = UDim2.fromScale(1, 1),
+			}),
+		})
+	end,
+}

--- a/src/Components/Sidebar.lua
+++ b/src/Components/Sidebar.lua
@@ -58,7 +58,7 @@ local function Sidebar(props: Props, hooks: any)
 		BackgroundColor3 = theme.sidebar,
 		BorderSizePixel = 0,
 		LayoutOrder = props.layoutOrder,
-		Size = UDim2.new(0, 267, 1, 0),
+		Size = UDim2.fromScale(1, 1),
 	}, {
 		UIListLayout = e("UIListLayout", {
 			Padding = theme.padding,

--- a/src/Components/StoryControls.lua
+++ b/src/Components/StoryControls.lua
@@ -48,6 +48,10 @@ local function StoryControls(props: Props, hooks: any)
 			Size = UDim2.fromScale(1, 0),
 			AutomaticSize = Enum.AutomaticSize.Y,
 		}, {
+			Layout = Roact.createElement("UIListLayout", {
+				FillDirection = Enum.FillDirection.Horizontal,
+			}),
+
 			Name = e("TextLabel", {
 				Text = key,
 				Size = UDim2.fromScale(1 / 2, 0),
@@ -63,7 +67,6 @@ local function StoryControls(props: Props, hooks: any)
 			Option = e("Frame", {
 				BackgroundTransparency = 1,
 				Size = UDim2.fromScale(1 / 2, 0),
-				Position = UDim2.fromScale(1 / 2, 0),
 				AutomaticSize = Enum.AutomaticSize.Y,
 			}, option),
 		})

--- a/src/Components/StoryView.lua
+++ b/src/Components/StoryView.lua
@@ -2,7 +2,7 @@ local flipbook = script:FindFirstAncestor("flipbook")
 
 local Selection = game:GetService("Selection")
 
-local Llama = require(flipbook.Packages.Llama)
+local Sift = require(flipbook.Packages.Sift)
 local Roact = require(flipbook.Packages.Roact)
 local hook = require(flipbook.hook)
 local types = require(script.Parent.Parent.types)
@@ -30,11 +30,11 @@ local function StoryView(props: Props, hooks: any)
 	local plugin = hooks.useContext(PluginContext.Context)
 	local controls, setControls = hooks.useState(nil)
 
-	local showControls = controls and not Llama.isEmpty(controls)
+	local showControls = controls and not Sift.isEmpty(controls)
 
 	local setControl = hooks.useCallback(function(control: string, newValue: any)
 		setControls(function(prevControls)
-			return Llama.Dictionary.join(prevControls, {
+			return Sift.Dictionary.merge(prevControls, {
 				[control] = newValue,
 			})
 		end)

--- a/src/Components/StoryView.lua
+++ b/src/Components/StoryView.lua
@@ -99,7 +99,7 @@ local function StoryView(props: Props, hooks: any)
 
 			ScrollingFrame = e(ScrollingFrame, {
 				LayoutOrder = 1,
-				Size = UDim2.fromScale(1, 1) - UDim2.fromOffset(0, controlsHeight),
+				Size = UDim2.fromScale(1, 1) - UDim2.fromOffset(0, if showControls then controlsHeight else 0),
 			}, {
 				Layout = e("UIListLayout", {
 					Padding = theme.padding,

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -2,6 +2,10 @@ return {
 	STORY_NAME_PATTERN = "%.story$",
 	STORYBOOK_NAME_PATTERN = "%.storybook$",
 
+	SIDEBAR_INITIAL_WIDTH = 260, -- px
+	SIDEBAR_MIN_WIDTH = 140, -- px
+	SIDEBAR_MAX_WIDTH = 500, -- px
+
 	-- Enabling dev mode will add flipbook's storybook to the list of available
 	-- storybooks to make localy testing easier. It also adds a [DEV] tag to the
 	-- plugin

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -6,6 +6,10 @@ return {
 	SIDEBAR_MIN_WIDTH = 140, -- px
 	SIDEBAR_MAX_WIDTH = 500, -- px
 
+	CONTROLS_INITIAL_HEIGHT = 200, -- px
+	CONTROLS_MIN_HEIGHT = 100, -- px
+	CONTROLS_MAX_HEIGHT = 400, -- px
+
 	-- Enabling dev mode will add flipbook's storybook to the list of available
 	-- storybooks to make localy testing easier. It also adds a [DEV] tag to the
 	-- plugin

--- a/src/types.lua
+++ b/src/types.lua
@@ -63,4 +63,6 @@ export type ComponentTreeNode = {
 	storybook: Storybook?,
 }
 
+export type DragHandle = "Top" | "Right" | "Bottom" | "Left"
+
 return {}


### PR DESCRIPTION
# Problem

Currently the panels for the sidebar and controls are static and cannot be resized. This can make it frustrating to use the button when the story view isn't big enough

# Solution

The sidebar and controls panels can now be independantly resized to the left/right and up/down, respectively

# Checklist

- [ ] Ran `./bin/test.sh` locally before merging
