### PR TITLE
Fix the test script

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,2 +1,3 @@
-rojo build dev.project.json -o studio-tests.rbxl
-run-in-roblox --place studio-tests.rbxl --script tests/init.server.lua
+rojo build tests.project.json -o tests.rbxl
+run-in-roblox --place tests.rbxl --script tests/init.server.lua
+rm tests.rbxl

--- a/tests.project.json
+++ b/tests.project.json
@@ -1,0 +1,20 @@
+{
+  "name": "flipbook",
+  "tree": {
+    "$className": "DataModel",
+    "ServerScriptService": {
+      "flipbook": {
+        "Packages": {
+          "$path": "Packages"
+        },
+        "Example": {
+          "$path": "example"
+        },
+        "TestRunner": {
+          "$path": "tests"
+        },
+        "$path": "src"
+      }
+    }
+  }
+}

--- a/tests/init.server.lua
+++ b/tests/init.server.lua
@@ -1,4 +1,6 @@
-local flipbook = script:FindFirstAncestor("flipbook")
+local ServerScriptService = game:GetService("ServerScriptService")
+
+local flipbook = script:FindFirstAncestor("flipbook") or ServerScriptService:FindFirstChild("flipbook")
 
 local TestEZ = require(flipbook.Packages.TestEZ)
 


### PR DESCRIPTION
# Problem

Running `./bin/test.sh` results in an error when attempting to access flipbook's packages

# Solution

Setup a new project to mount flipbook in ServerScriptService and updated the test script to look for flipbook there if it cannot be found as an ancestor

# Checklist

- [x] Ran `./bin/test.sh` locally before merging
