### PR TITLE
Fix example that throws an error when used

### DIFF
--- a/docs/story-format.md
+++ b/docs/story-format.md
@@ -133,7 +133,7 @@ return {
 
 		local padding = Instance.new("UIPadding")
 		padding.PaddingTop = UDim.new(0, 8)
-		padding.Right = padding.PaddingTop
+		padding.PaddingRight = padding.PaddingTop
 		padding.PaddingBottom = padding.PaddingTop
 		padding.PaddingLeft = padding.PaddingTop
 		padding.Parent = label


### PR DESCRIPTION
# Problem

The example functional story throws an error when used verbatim

# Solution

Fixed `padding.Right` to `padding.PaddingRight`

Closes #156 
