### PR TITLE
Use a flag for ignoring packages

### DIFF
--- a/.github/workflows/.luaurc
+++ b/.github/workflows/.luaurc
@@ -1,6 +1,0 @@
-{
-  "languageMode": "nocheck",
-  "lint": {
-    "*": true
-  }
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,9 @@ jobs:
         shell: bash
         run: rojo sourcemap dev.project.json -o sourcemap.json
 
-      - name: Ignore packages in analysis
-        shell: bash
-        run: mv .github/workflows/.luaurc Packages
-
       - name: Analyze
         shell: bash
-        run: luau-lsp analyze --sourcemap=sourcemap.json --defs=globalTypes.d.lua --defs=testez.d.lua --formatter=gnu src/
+        run: luau-lsp analyze --sourcemap=sourcemap.json --defs=globalTypes.d.lua --defs=testez.d.lua --ignore=**/_Index/** src/
 
   scripts:
     runs-on: ubuntu-latest

--- a/bin/analyze.sh
+++ b/bin/analyze.sh
@@ -2,10 +2,8 @@
 
 curl -s -O https://raw.githubusercontent.com/JohnnyMorganz/luau-lsp/master/scripts/globalTypes.d.lua
 
-cp .github/workflows/.luaurc Packages
 rojo sourcemap dev.project.json -o sourcemap.json
 
-luau-lsp analyze --sourcemap=sourcemap.json --defs=globalTypes.d.lua --defs=testez.d.lua src/
+luau-lsp analyze --sourcemap=sourcemap.json --defs=globalTypes.d.lua --defs=testez.d.lua --ignore=**/_Index/** src/
 
-rm Packages/.luaurc
 rm globalTypes.d.lua


### PR DESCRIPTION
# Problem

Right now we're ignoring packages by copying a .luaurc file into the `Packages` directory before running analysis. This is the purpose of the `--ignore` flag which we should be using instead

# Solution

This PR switches us over to using the `--ignore` flag in CI and in the `analyze.sh` script

