### PR TITLE
Add button to view mounted story instances

### DIFF
--- a/src/Components/StoryPreview.lua
+++ b/src/Components/StoryPreview.lua
@@ -22,13 +22,13 @@ type Props = typeof(defaultProps) & {
 	storyModule: ModuleScript,
 }
 
-local function StoryPreview(props: Props)
+local StoryPreview = React.forwardRef(function(props: Props, ref: any)
 	props = Sift.Dictionary.merge(defaultProps, props)
 
 	React.useEffect(function()
 		local cleanup
-		if props.story then
-			cleanup = mountStory(props.story, props.controls, props.ref.current)
+		if props.story and ref.current then
+			cleanup = mountStory(props.story, props.controls, ref.current)
 		end
 
 		return function()
@@ -36,14 +36,14 @@ local function StoryPreview(props: Props)
 				cleanup()
 			end
 		end
-	end, { props.story, props.controls, props.ref })
+	end, { props.story, props.controls, ref.current })
 
 	if props.isMountedInViewport then
 		return e(React.Portal, {
 			target = CoreGui,
 		}, {
 			Story = e("ScreenGui", {
-				ref = props.ref,
+				ref = ref,
 			}),
 		})
 	else
@@ -52,13 +52,13 @@ local function StoryPreview(props: Props)
 			BackgroundTransparency = 1,
 			LayoutOrder = props.layoutOrder,
 			Size = UDim2.fromScale(1, 0),
-			ref = props.ref,
+			ref = ref,
 		}, {
 			Scale = e("UIScale", {
 				Scale = 1 + props.zoom,
 			}),
 		})
 	end
-end
+end)
 
 return StoryPreview

--- a/src/Components/StoryPreview.lua
+++ b/src/Components/StoryPreview.lua
@@ -17,17 +17,16 @@ local defaultProps = {
 type Props = typeof(defaultProps) & {
 	layoutOrder: number,
 	story: types.Story,
+	ref: any,
 	controls: { [string]: any },
 	storyModule: ModuleScript,
 }
 
 local function StoryPreview(props: Props, hooks: any)
-	local storyParent = Roact.createRef()
-
 	hooks.useEffect(function()
 		local cleanup
 		if props.story then
-			cleanup = mountStory(props.story, props.controls, storyParent:getValue())
+			cleanup = mountStory(props.story, props.controls, props.ref:getValue())
 		end
 
 		return function()
@@ -35,14 +34,14 @@ local function StoryPreview(props: Props, hooks: any)
 				cleanup()
 			end
 		end
-	end, { props.story, storyParent })
+	end, { props.story, props.ref })
 
 	if props.isMountedInViewport then
 		return e(Roact.Portal, {
 			target = CoreGui,
 		}, {
 			Story = e("ScreenGui", {
-				[Roact.Ref] = storyParent,
+				[Roact.Ref] = props.ref,
 			}),
 		})
 	else
@@ -51,7 +50,7 @@ local function StoryPreview(props: Props, hooks: any)
 			BackgroundTransparency = 1,
 			LayoutOrder = props.layoutOrder,
 			Size = UDim2.fromScale(1, 0),
-			[Roact.Ref] = storyParent,
+			[Roact.Ref] = props.ref,
 		}, {
 			Scale = e("UIScale", {
 				Scale = 1 + props.zoom,

--- a/src/Components/StoryView.lua
+++ b/src/Components/StoryView.lua
@@ -117,7 +117,7 @@ local function StoryView(props: Props)
 					onZoomIn = zoom.zoomIn,
 					onZoomOut = zoom.zoomOut,
 					onViewCode = viewCode,
-					onExplore = exploreStoryParent,
+					onExplorer = exploreStoryParent,
 				}),
 			}),
 

--- a/src/Components/StoryView.lua
+++ b/src/Components/StoryView.lua
@@ -34,6 +34,7 @@ local function StoryView(props: Props, hooks: any)
 	local controls, setControls = hooks.useState(nil)
 	local controlsHeight, setControlsHeight = hooks.useState(constants.CONTROLS_INITIAL_HEIGHT)
 	local topbarHeight, setTopbarHeight = hooks.useState(0)
+	local storyParentRef = Roact.createRef()
 
 	local showControls = controls and not Sift.isEmpty(controls)
 
@@ -49,6 +50,12 @@ local function StoryView(props: Props, hooks: any)
 		Selection:Set({ props.story })
 		plugin:OpenScript(props.story)
 	end, { plugin, props.story })
+
+	local exploreStoryParent = hooks.useCallback(function()
+		Selection:Set({ storyParentRef.current })
+
+		-- TODO: If PluginGuiService is not enabled, display a toast letting the user know
+	end, { storyParentRef })
 
 	local isMountedInViewport, setIsMountedInViewport = hooks.useState(false)
 
@@ -111,6 +118,7 @@ local function StoryView(props: Props, hooks: any)
 					onZoomIn = zoom.zoomIn,
 					onZoomOut = zoom.zoomOut,
 					onViewCode = viewCode,
+					onExplore = exploreStoryParent,
 				}),
 			}),
 
@@ -152,6 +160,7 @@ local function StoryView(props: Props, hooks: any)
 					controls = controls,
 					storyModule = props.story,
 					isMountedInViewport = isMountedInViewport,
+					ref = storyParentRef,
 				}),
 			}),
 

--- a/src/Components/StoryView.lua
+++ b/src/Components/StoryView.lua
@@ -51,7 +51,11 @@ local function StoryView(props: Props)
 	end, { plugin, props.story })
 
 	local exploreStoryParent = React.useCallback(function()
-		Selection:Set({ storyParentRef.current })
+		local current = storyParentRef.current
+		if current then
+			local firstGuiObject = current:FindFirstChildWhichIsA("GuiObject")
+			Selection:Set({ if firstGuiObject then firstGuiObject else current })
+		end
 
 		-- TODO: If PluginGuiService is not enabled, display a toast letting the user know
 	end, { storyParentRef })

--- a/src/Components/StoryViewNavbar.lua
+++ b/src/Components/StoryViewNavbar.lua
@@ -15,6 +15,7 @@ type Props = {
 	onZoomIn: (() -> ())?,
 	onZoomOut: (() -> ())?,
 	onViewCode: (() -> ())?,
+	onExplore: (() -> ())?,
 }
 
 local function NavbarRoot(props: Props, hooks: any)
@@ -60,6 +61,23 @@ local function NavbarRoot(props: Props, hooks: any)
 			Mount = e(Navbar.Items, {
 				layoutOrder = 4,
 			}, {
+				Explore = e(Navbar.Item, {
+					layoutOrder = 1,
+					onClick = props.onExplore,
+				}, {
+					Text = e("TextLabel", {
+						AutomaticSize = Enum.AutomaticSize.XY,
+						BackgroundTransparency = 1,
+						Font = theme.font,
+						Size = UDim2.fromScale(0, 0),
+						Text = "Explore",
+						TextColor3 = theme.textFaded,
+						TextSize = theme.textSize,
+						TextXAlignment = Enum.TextXAlignment.Left,
+						TextYAlignment = Enum.TextYAlignment.Top,
+					}),
+				}),
+
 				ViewCode = e(Navbar.Item, {
 					layoutOrder = 1,
 					onClick = props.onViewCode,

--- a/src/Components/StoryViewNavbar.lua
+++ b/src/Components/StoryViewNavbar.lua
@@ -14,7 +14,7 @@ type Props = {
 	onZoomIn: (() -> ())?,
 	onZoomOut: (() -> ())?,
 	onViewCode: (() -> ())?,
-	onExplore: (() -> ())?,
+	onExplorer: (() -> ())?,
 }
 
 local function NavbarRoot(props: Props)
@@ -60,16 +60,16 @@ local function NavbarRoot(props: Props)
 			Mount = e(Navbar.Items, {
 				layoutOrder = 4,
 			}, {
-				Explore = e(Navbar.Item, {
+				Explorer = e(Navbar.Item, {
 					layoutOrder = 1,
-					onClick = props.onExplore,
+					onClick = props.onExplorer,
 				}, {
 					Text = e("TextLabel", {
 						AutomaticSize = Enum.AutomaticSize.XY,
 						BackgroundTransparency = 1,
 						Font = theme.font,
 						Size = UDim2.fromScale(0, 0),
-						Text = "Explore",
+						Text = "Explorer",
 						TextColor3 = theme.textFaded,
 						TextSize = theme.textSize,
 						TextXAlignment = Enum.TextXAlignment.Left,


### PR DESCRIPTION
# Problem

It's important to be able to view the gui instances that a story produces, but to do this the user must manually navigate all the way down to `PluginGuiService.flipbook.Background.MainWrapper.Canvas.Content.StoryView.Content.ScrollingFrame.StoryPreview`

# Solution

A new "Explore" button has been added which will set the user's selection to `StoryPreview` to make it easier to then navigate into the story's hierarchy to view the mounted instances

Closes #147

# Checklist

- [x] Ran `./bin/test.sh` locally before merging
