### PR TITLE
Only deploy docs on release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,8 @@ name: Docs
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 env:
   REPO_URL: github.com/vocksel/flipbook
@@ -41,5 +40,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event.release }}
         run: moonwave build --publish


### PR DESCRIPTION
# Problem

Docs are deploying on each push to the main branch which means our documentation can have changes that don't apply to the current release of flipbook

# Solution

Everything (except deployment) is still run on PRs to ensure our documentation can be built, but now deployment will only happen when a release is published (instead of pushing to main)
