### PR TITLE
Better error handling

### DIFF
--- a/src/Components/StoryPreview.lua
+++ b/src/Components/StoryPreview.lua
@@ -4,6 +4,7 @@ local flipbook = script:FindFirstAncestor("flipbook")
 
 local React = require(flipbook.Packages.React)
 local Sift = require(flipbook.Packages.Sift)
+local useTheme = require(flipbook.Hooks.useTheme)
 local types = require(script.Parent.Parent.types)
 local mountStory = require(flipbook.Story.mountStory)
 
@@ -24,41 +25,71 @@ type Props = typeof(defaultProps) & {
 local function StoryPreview(props: Props)
 	props = Sift.Dictionary.merge(defaultProps, props)
 
+	local theme = useTheme()
+	local err, setErr = React.useState(nil)
 	local storyParent = React.useRef()
 
 	React.useEffect(function()
-		local cleanup
-		if props.story then
-			cleanup = mountStory(props.story, props.controls, storyParent:getValue())
-		end
+		setErr(nil)
 
-		return function()
-			if cleanup then
-				cleanup()
+		if props.story then
+			local success, result = xpcall(function()
+				return mountStory(props.story, props.controls, storyParent.current)
+			end, debug.traceback)
+
+			if success then
+				return result
+			else
+				setErr(result)
+				return nil
 			end
 		end
+
+		return nil
 	end, { props.story, props.controls, storyParent })
 
-	if props.isMountedInViewport then
-		return e(React.Portal, {
-			target = CoreGui,
+	if err then
+		return e("TextLabel", {
+			LayoutOrder = props.layoutOrder,
+			BackgroundTransparency = 1,
+			Font = theme.font,
+			Size = UDim2.fromScale(1, 1),
+			Text = err,
+			TextColor3 = theme.text,
+			TextWrapped = true,
+			TextSize = theme.textSize,
+			TextXAlignment = Enum.TextXAlignment.Left,
+			TextYAlignment = Enum.TextYAlignment.Top,
 		}, {
-			Story = e("ScreenGui", {
-				ref = storyParent,
+			Padding = e("UIPadding", {
+				PaddingTop = theme.padding,
+				PaddingRight = theme.padding,
+				PaddingBottom = theme.padding,
+				PaddingLeft = theme.padding,
 			}),
 		})
 	else
-		return e("Frame", {
-			AutomaticSize = Enum.AutomaticSize.Y,
-			BackgroundTransparency = 1,
-			LayoutOrder = props.layoutOrder,
-			Size = UDim2.fromScale(1, 0),
-			ref = storyParent,
-		}, {
-			Scale = e("UIScale", {
-				Scale = 1 + props.zoom,
-			}),
-		})
+		if props.isMountedInViewport then
+			return e(React.Portal, {
+				target = CoreGui,
+			}, {
+				Story = e("ScreenGui", {
+					ref = storyParent,
+				}),
+			})
+		else
+			return e("Frame", {
+				AutomaticSize = Enum.AutomaticSize.Y,
+				BackgroundTransparency = 1,
+				LayoutOrder = props.layoutOrder,
+				Size = UDim2.fromScale(1, 0),
+				ref = storyParent,
+			}, {
+				Scale = e("UIScale", {
+					Scale = 1 + props.zoom,
+				}),
+			})
+		end
 	end
 end
 

--- a/src/Story/mountStory.lua
+++ b/src/Story/mountStory.lua
@@ -1,20 +1,12 @@
 local types = require(script.Parent.Parent.types)
 
 local function mountFunctionalStory(story: types.FunctionalStory, props: types.StoryProps, parent: GuiObject)
-	local cleanup: (() -> ())?
-
-	xpcall(function()
-		cleanup = story.story(parent, props)
-	end, debug.traceback)
+	local cleanup = story.story(parent, props)
 
 	return function()
 		if typeof(cleanup) == "function" then
 			cleanup()
 		end
-
-		-- TODO: First find a way to ensure the UIScale in `parent` won't be
-		-- destroyed by calling this
-		-- parent:ClearAllChildren()
 	end
 end
 
@@ -23,24 +15,15 @@ local function mountRoactStory(story: types.RoactStory, props: types.StoryProps,
 
 	local element
 	if typeof(story.story) == "function" then
-		local success, result = pcall(function()
-			return Roact.createElement(story.story, props)
-		end)
-
-		element = if success then result else nil
+		element = Roact.createElement(story.story, props)
 	else
 		element = story.story
 	end
 
-	local handle
-	xpcall(function()
-		handle = Roact.mount(element, parent, story.name)
-	end, debug.traceback)
+	local handle = Roact.mount(element, parent, story.name)
 
 	return function()
-		if handle then
-			Roact.unmount(handle)
-		end
+		Roact.unmount(handle)
 	end
 end
 
@@ -52,16 +35,12 @@ local function mountReactStory(story: types.ReactStory, props: types.StoryProps,
 
 	local element
 	if typeof(story.story) == "function" then
-		xpcall(function()
-			element = React.createElement(story.story, props)
-		end, debug.traceback)
+		element = React.createElement(story.story, props)
 	else
 		element = story.story
 	end
 
-	xpcall(function()
-		root:render(element)
-	end, debug.traceback)
+	root:render(element)
 
 	return function()
 		root:unmount()


### PR DESCRIPTION
# Problem

- No logging for malformed storybooks
- No logging for malformed stories
- When a story errors it doesn't always show up in the preview (only the Functional format?)
- React might bloat our stacktraces. We may need to do some parsing to narrow down the stacktrace 
- #160
- #162
- #171

# Solution

WIP WIP WIP

# Media

Functional story error:
<img width="1624" alt="Screenshot 2023-01-16 at 1 49 01 PM" src="https://user-images.githubusercontent.com/3081936/212770704-09fb41eb-b773-4e0c-a24a-f3023502e77d.png">

Roact story error
<img width="1624" alt="Screenshot 2023-01-16 at 1 50 43 PM" src="https://user-images.githubusercontent.com/3081936/212770831-f64ad302-7c9e-4b50-9ff9-fc2ff62951fb.png">


# Checklist

- [ ] Ran `./bin/test.sh` locally before merging
