### PR TITLE
Attach plugin builds to action runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: build
+          name: ${{ env.MODEL_FILE }}
           path: ${{ env.MODEL_FILE }}
 
   analyze:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,19 @@ jobs:
       - name: Install dependencies
         run: wally install
 
+      - name: Get model file name
+        run: |
+          name=$(jq -r .name default.project.json)
+          sha=${GITHUB_SHA:0:7}
+          echo "MODEL_FILE=$name-$sha.rbxm" >> $GITHUB_ENV
+
       - name: Build
-        run: rojo build -o build.rbxm
+        run: rojo build -o ${{ env.MODEL_FILE }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: ${{ env.MODEL_FILE }}
 
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: Roblox/setup-foreman@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
   release:
     types: [published]
 
-env:
-  OUTPUT_NAME: "flipbook.rbxm"
-
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -24,12 +21,17 @@ jobs:
       - name: Install packages
         run: wally install
 
+      - name: Get model file name
+        run: |
+          name=$(jq -r .name default.project.json)
+          echo "MODEL_FILE=$name.rbxm" >> $GITHUB_ENV
+
       - name: Build
-        run: rojo build -o ${{ env.OUTPUT_NAME }}
+        run: rojo build -o ${{ env.MODEL_FILE }}
 
       - uses: softprops/action-gh-release@v1
         if: ${{ github.event.release }}
         with:
-          files: ${{ env.OUTPUT_NAME }}
+          files: ${{ env.MODEL_FILE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Action summaries now include a built copy of flipbook at that commit. This way if anyone wants to try out the bleeding edge they can

![Screenshot 2023-01-16 at 4 52 44 PM](https://user-images.githubusercontent.com/3081936/212787378-9b31fba2-e643-42fc-b734-bfd81c9c45ce.png)

https://github.com/vocksel/flipbook/actions/runs/3935053803