### PR TITLE
Clear the cache when reloading the plugin

### DIFF
--- a/src/Components/App.lua
+++ b/src/Components/App.lua
@@ -1,6 +1,5 @@
 local flipbook = script:FindFirstAncestor("flipbook")
 
-local ModuleLoader = require(flipbook.Packages.ModuleLoader)
 local React = require(flipbook.Packages.React)
 local constants = require(flipbook.constants)
 local useStorybooks = require(flipbook.Hooks.useStorybooks)
@@ -10,15 +9,14 @@ local ResizablePanel = require(script.Parent.ResizablePanel)
 local Canvas = require(script.Parent.Canvas)
 local Sidebar = require(script.Parent.Sidebar)
 
-local loader = ModuleLoader.new()
-
 export type Props = {
 	plugin: Plugin,
+	loader: any,
 }
 
 local function App(props: Props)
 	local theme = useTheme()
-	local storybooks = useStorybooks(game, loader)
+	local storybooks = useStorybooks(game, props.loader)
 	local story, setStory = React.useState(nil)
 	local storybook, selectStorybook = React.useState(nil)
 	local sidebarWidth, setSidebarWidth = React.useState(constants.SIDEBAR_INITIAL_WIDTH)
@@ -66,7 +64,7 @@ local function App(props: Props)
 				Size = UDim2.fromScale(1, 1) - UDim2.fromOffset(sidebarWidth, 0),
 			}, {
 				Canvas = React.createElement(Canvas, {
-					loader = loader,
+					loader = props.loader,
 					story = story,
 					storybook = storybook,
 				}),

--- a/src/init.server.lua
+++ b/src/init.server.lua
@@ -6,6 +6,7 @@ if RunService:IsRunning() or not RunService:IsEdit() then
 	return
 end
 
+local ModuleLoader = require(flipbook.Packages.ModuleLoader)
 local React = require(flipbook.Packages.React)
 local ReactRoblox = require(flipbook.Packages.ReactRoblox)
 local createWidget = require(flipbook.Plugin.createWidget)
@@ -24,8 +25,11 @@ local widget = createWidget(plugin, PLUGIN_NAME)
 local root = ReactRoblox.createRoot(widget)
 local disconnectButton = createToggleButton(toolbar, widget)
 
+local loader = ModuleLoader.new()
+
 local app = React.createElement(App, {
 	plugin = plugin,
+	loader = loader,
 })
 
 local widgetConn = widget:GetPropertyChangedSignal("Enabled"):Connect(function()
@@ -33,6 +37,7 @@ local widgetConn = widget:GetPropertyChangedSignal("Enabled"):Connect(function()
 		root:render(app)
 	else
 		root:unmount()
+		loader:clear()
 	end
 end)
 
@@ -45,4 +50,5 @@ plugin.Unloading:Connect(function()
 	widgetConn:Disconnect()
 
 	root:unmount()
+	loader:clear()
 end)


### PR DESCRIPTION
# Problem

flipbook's cache isn't clearing when reloading the plugin, resulting in getting stuck in error states

# Solution

The ModuleLoader instance is now created in the main server script and cleared any time the plugin is unloaded. This results in closing and reopening the plugin starting with a brand new cache which which fix issues where flipbook would get stuck in error states from story errors

Resolves #184

# Checklist

- [x] Ran `./bin/test.sh` locally before merging
