### PR TITLE
Make error text selectable

### DIFF
--- a/src/Components/SelectableTextLabel.lua
+++ b/src/Components/SelectableTextLabel.lua
@@ -1,0 +1,34 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local React = require(flipbook.Packages.React)
+local Sift = require(flipbook.Packages.Sift)
+local useTheme = require(flipbook.Hooks.useTheme)
+
+local defaultProps = {
+	AutomaticSize = Enum.AutomaticSize.XY,
+	BackgroundTransparency = 1,
+	ClearTextOnFocus = false,
+	ClipsDescendants = true,
+	TextEditable = false,
+	TextWrapped = true,
+	TextXAlignment = Enum.TextXAlignment.Left,
+	TextYAlignment = Enum.TextYAlignment.Top,
+}
+
+type Props = {
+	[string]: any,
+}
+
+local function SelectableTextLabel(providedProps: Props)
+	local theme = useTheme()
+
+	local props = Sift.Dictionary.merge(defaultProps, {
+		TextSize = theme.textSize,
+		Font = theme.font,
+		TextColor3 = theme.text,
+	}, providedProps)
+
+	return React.createElement("TextBox", props)
+end
+
+return SelectableTextLabel

--- a/src/Components/SelectableTextLabel.story.lua
+++ b/src/Components/SelectableTextLabel.story.lua
@@ -1,0 +1,22 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local React = require(flipbook.Packages.React)
+local SelectableTextLabel = require(script.Parent.SelectableTextLabel)
+
+local controls = {
+	text = "Ad proident sit nulla incididunt do nisi amet velit velit...",
+}
+
+type Props = {
+	controls: typeof(controls),
+}
+
+return {
+	summary = "A styled TextLabel with selectable text. Click and drag with the mouse to select content",
+	controls = controls,
+	story = function(props: Props)
+		return React.createElement(SelectableTextLabel, {
+			Text = props.controls.text,
+		})
+	end,
+}

--- a/src/Components/StoryError.lua
+++ b/src/Components/StoryError.lua
@@ -1,0 +1,22 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local React = require(flipbook.Packages.React)
+local SelectableTextLabel = require(flipbook.Components.SelectableTextLabel)
+local useTheme = require(flipbook.Hooks.useTheme)
+
+export type Props = {
+	err: string,
+	layoutOrder: number?,
+}
+
+local function StoryError(props: Props)
+	local theme = useTheme()
+
+	return React.createElement(SelectableTextLabel, {
+		LayoutOrder = props.layoutOrder,
+		Text = props.err,
+		TextColor3 = theme.alert,
+	})
+end
+
+return StoryError

--- a/src/Components/StoryError.story.lua
+++ b/src/Components/StoryError.story.lua
@@ -1,0 +1,17 @@
+local flipbook = script:FindFirstAncestor("flipbook")
+
+local React = require(flipbook.Packages.React)
+local StoryError = require(script.Parent.StoryError)
+
+return {
+	summary = "Component for displaying error messages to the user",
+	story = function()
+		local success, result = xpcall(function()
+			error("Oops!")
+		end, debug.traceback)
+
+		return React.createElement(StoryError, {
+			err = result,
+		})
+	end,
+}

--- a/src/Components/StoryError.story.lua
+++ b/src/Components/StoryError.story.lua
@@ -6,7 +6,7 @@ local StoryError = require(script.Parent.StoryError)
 return {
 	summary = "Component for displaying error messages to the user",
 	story = function()
-		local success, result = xpcall(function()
+		local _, result = xpcall(function()
 			error("Oops!")
 		end, debug.traceback)
 

--- a/src/Components/StoryPreview.lua
+++ b/src/Components/StoryPreview.lua
@@ -5,7 +5,7 @@ local flipbook = script:FindFirstAncestor("flipbook")
 local React = require(flipbook.Packages.React)
 local ReactRoblox = require(flipbook.Packages.ReactRoblox)
 local Sift = require(flipbook.Packages.Sift)
-local useTheme = require(flipbook.Hooks.useTheme)
+local StoryError = require(flipbook.Components.StoryError)
 local types = require(script.Parent.Parent.types)
 local mountStory = require(flipbook.Story.mountStory)
 
@@ -27,12 +27,13 @@ type Props = typeof(defaultProps) & {
 local StoryPreview = React.forwardRef(function(props: Props, ref: any)
 	props = Sift.Dictionary.merge(defaultProps, props)
 
-	local theme = useTheme()
 	local err, setErr = React.useState(nil)
 
 	React.useEffect(function()
 		setErr(nil)
+	end, { props.story, ref })
 
+	React.useEffect(function()
 		if props.story and ref.current then
 			local success, result = xpcall(function()
 				return mountStory(props.story, props.controls, ref.current)
@@ -50,24 +51,9 @@ local StoryPreview = React.forwardRef(function(props: Props, ref: any)
 	end, { props.story, props.controls, props.isMountedInViewport, ref.current })
 
 	if err then
-		return e("TextLabel", {
-			LayoutOrder = props.layoutOrder,
-			BackgroundTransparency = 1,
-			Font = theme.font,
-			Size = UDim2.fromScale(1, 1),
-			Text = err,
-			TextColor3 = theme.text,
-			TextWrapped = true,
-			TextSize = theme.textSize,
-			TextXAlignment = Enum.TextXAlignment.Left,
-			TextYAlignment = Enum.TextYAlignment.Top,
-		}, {
-			Padding = e("UIPadding", {
-				PaddingTop = theme.padding,
-				PaddingRight = theme.padding,
-				PaddingBottom = theme.padding,
-				PaddingLeft = theme.padding,
-			}),
+		return e(StoryError, {
+			layoutOrder = props.layoutOrder,
+			err = err,
 		})
 	else
 		if props.isMountedInViewport then

--- a/src/Components/StoryView.lua
+++ b/src/Components/StoryView.lua
@@ -13,6 +13,7 @@ local StoryViewNavbar = require(flipbook.Components.StoryViewNavbar)
 local StoryControls = require(flipbook.Components.StoryControls)
 local StoryMeta = require(flipbook.Components.StoryMeta)
 local StoryPreview = require(flipbook.Components.StoryPreview)
+local StoryError = require(flipbook.Components.StoryError)
 local ResizablePanel = require(flipbook.Components.ResizablePanel)
 local ScrollingFrame = require(flipbook.Components.ScrollingFrame)
 local PluginContext = require(flipbook.Plugin.PluginContext)
@@ -82,23 +83,8 @@ local function StoryView(props: Props)
 		Size = UDim2.fromScale(1, 1),
 		BackgroundTransparency = 1,
 	}, {
-		Error = storyErr and e("TextLabel", {
-			BackgroundTransparency = 1,
-			Font = theme.font,
-			Size = UDim2.fromScale(1, 1),
-			Text = storyErr,
-			TextColor3 = theme.text,
-			TextWrapped = true,
-			TextSize = theme.textSize,
-			TextXAlignment = Enum.TextXAlignment.Left,
-			TextYAlignment = Enum.TextYAlignment.Top,
-		}, {
-			Padding = e("UIPadding", {
-				PaddingTop = theme.padding,
-				PaddingRight = theme.padding,
-				PaddingBottom = theme.padding,
-				PaddingLeft = theme.padding,
-			}),
+		Error = storyErr and e(StoryError, {
+			err = storyErr,
 		}),
 
 		Content = story and e("Frame", {

--- a/src/themes.lua
+++ b/src/themes.lua
@@ -22,6 +22,7 @@ return {
 		selection = tailwind.purple500,
 		story = tailwind.green500,
 		directory = tailwind.purple500,
+		alert = tailwind.rose500,
 
 		padding = UDim.new(0, 12),
 		paddingSmall = UDim.new(0, 6),
@@ -48,6 +49,7 @@ return {
 		selection = tailwind.purple500,
 		story = tailwind.green500,
 		directory = tailwind.purple500,
+		alert = tailwind.rose500,
 
 		padding = UDim.new(0, 12),
 		paddingSmall = UDim.new(0, 6),


### PR DESCRIPTION
# Problem

Error text is not selectable, making it difficult to share errors when something breaks in a story

# Solution

Error text is now selectable and colored as red to make it easier to see that it's an error

Closes #180 

# Checklist

- [x] Ran `./bin/test.sh` locally before merging
