### PR TITLE
Fix story preview sizing

### DIFF
--- a/example/CanvasTests/AutomaticSize.story.lua
+++ b/example/CanvasTests/AutomaticSize.story.lua
@@ -4,7 +4,7 @@ local React = require(Example.Parent.Packages.React)
 local ReactRoblox = require(Example.Parent.Packages.ReactRoblox)
 
 return {
-	summary = "",
+	summary = "AutoamticSize test for the story preview",
 	react = React,
 	reactRoblox = ReactRoblox,
 	story = function()

--- a/example/CanvasTests/AutomaticSize.story.lua
+++ b/example/CanvasTests/AutomaticSize.story.lua
@@ -1,0 +1,20 @@
+local Example = script:FindFirstAncestor("Example")
+
+local React = require(Example.Parent.Packages.React)
+local ReactRoblox = require(Example.Parent.Packages.ReactRoblox)
+
+return {
+	summary = "",
+	react = React,
+	reactRoblox = ReactRoblox,
+	story = function()
+		return React.createElement("TextLabel", {
+			Size = UDim2.new(0, 0, 0, 0),
+			AutomaticSize = Enum.AutomaticSize.XY,
+
+			TextSize = 24,
+			Text = script.Name,
+			Font = Enum.Font.GothamBold,
+		})
+	end,
+}

--- a/example/CanvasTests/AutomaticSizeExceedsBounds.story.lua
+++ b/example/CanvasTests/AutomaticSizeExceedsBounds.story.lua
@@ -1,0 +1,20 @@
+local Example = script:FindFirstAncestor("Example")
+
+local React = require(Example.Parent.Packages.React)
+local ReactRoblox = require(Example.Parent.Packages.ReactRoblox)
+
+return {
+	summary = "AutoamticSize test using a height that exceeds the story preview",
+	react = React,
+	reactRoblox = ReactRoblox,
+	story = function()
+		return React.createElement("TextLabel", {
+			Size = UDim2.fromScale(1, 0),
+			AutomaticSize = Enum.AutomaticSize.Y,
+
+			TextSize = 24,
+			Text = script.Name .. string.rep("\nLine", 100),
+			Font = Enum.Font.GothamBold,
+		})
+	end,
+}

--- a/example/CanvasTests/Offset.story.lua
+++ b/example/CanvasTests/Offset.story.lua
@@ -1,0 +1,20 @@
+local Example = script:FindFirstAncestor("Example")
+
+local React = require(Example.Parent.Packages.React)
+local ReactRoblox = require(Example.Parent.Packages.ReactRoblox)
+
+return {
+	summary = "",
+	react = React,
+	reactRoblox = ReactRoblox,
+	story = function()
+		return React.createElement("TextLabel", {
+			Size = UDim2.fromOffset(2000, 2000),
+			AutomaticSize = Enum.AutomaticSize.None,
+
+			TextSize = 24,
+			Text = script.Name,
+			Font = Enum.Font.GothamBold,
+		})
+	end,
+}

--- a/example/CanvasTests/Offset.story.lua
+++ b/example/CanvasTests/Offset.story.lua
@@ -4,7 +4,7 @@ local React = require(Example.Parent.Packages.React)
 local ReactRoblox = require(Example.Parent.Packages.ReactRoblox)
 
 return {
-	summary = "",
+	summary = "Offset test for the story preview",
 	react = React,
 	reactRoblox = ReactRoblox,
 	story = function()

--- a/example/CanvasTests/Resizing.story.lua
+++ b/example/CanvasTests/Resizing.story.lua
@@ -35,7 +35,7 @@ local function Story()
 end
 
 return {
-	summary = "",
+	summary = "Resizing test for the story preview",
 	react = React,
 	reactRoblox = ReactRoblox,
 	story = function()

--- a/example/CanvasTests/Resizing.story.lua
+++ b/example/CanvasTests/Resizing.story.lua
@@ -1,0 +1,44 @@
+local Example = script:FindFirstAncestor("Example")
+
+local RunService = game:GetService("RunService")
+
+local React = require(Example.Parent.Packages.React)
+local ReactRoblox = require(Example.Parent.Packages.ReactRoblox)
+
+local RESIZE_DURATIOn = 3 -- seconds
+local MAX_SIZE = 2000 -- px
+
+local function Story()
+	local alpha, setAlpha = React.useState(0)
+
+	React.useEffect(function()
+		local conn = RunService.Heartbeat:Connect(function(dt)
+			setAlpha(function(prev)
+				local newAlpha = prev + (dt / RESIZE_DURATIOn)
+				return if newAlpha > 1 then 0 else newAlpha
+			end)
+		end)
+
+		return function()
+			conn:Disconnect()
+		end
+	end, {})
+
+	return React.createElement("TextLabel", {
+		Size = UDim2.fromOffset(MAX_SIZE * alpha, MAX_SIZE * alpha),
+		AutomaticSize = Enum.AutomaticSize.None,
+
+		TextSize = 24,
+		Text = script.Name,
+		Font = Enum.Font.GothamBold,
+	})
+end
+
+return {
+	summary = "",
+	react = React,
+	reactRoblox = ReactRoblox,
+	story = function()
+		return React.createElement(Story)
+	end,
+}

--- a/example/CanvasTests/Scale.story.lua
+++ b/example/CanvasTests/Scale.story.lua
@@ -1,0 +1,20 @@
+local Example = script:FindFirstAncestor("Example")
+
+local React = require(Example.Parent.Packages.React)
+local ReactRoblox = require(Example.Parent.Packages.ReactRoblox)
+
+return {
+	summary = "",
+	react = React,
+	reactRoblox = ReactRoblox,
+	story = function()
+		return React.createElement("TextLabel", {
+			Size = UDim2.fromScale(1, 1),
+			AutomaticSize = Enum.AutomaticSize.None,
+
+			TextSize = 24,
+			Text = script.Name,
+			Font = Enum.Font.GothamBold,
+		})
+	end,
+}

--- a/example/CanvasTests/Scale.story.lua
+++ b/example/CanvasTests/Scale.story.lua
@@ -4,7 +4,7 @@ local React = require(Example.Parent.Packages.React)
 local ReactRoblox = require(Example.Parent.Packages.ReactRoblox)
 
 return {
-	summary = "",
+	summary = "Scale test for the story preview",
 	react = React,
 	reactRoblox = ReactRoblox,
 	story = function()

--- a/example/CanvasTests/ScrollingFrame.story.lua
+++ b/example/CanvasTests/ScrollingFrame.story.lua
@@ -4,7 +4,7 @@ local React = require(Example.Parent.Packages.React)
 local ReactRoblox = require(Example.Parent.Packages.ReactRoblox)
 
 return {
-	summary = "",
+	summary = "ScrollingFrame test for the story preview",
 	react = React,
 	reactRoblox = ReactRoblox,
 	story = function()

--- a/example/CanvasTests/ScrollingFrame.story.lua
+++ b/example/CanvasTests/ScrollingFrame.story.lua
@@ -1,0 +1,24 @@
+local Example = script:FindFirstAncestor("Example")
+
+local React = require(Example.Parent.Packages.React)
+local ReactRoblox = require(Example.Parent.Packages.ReactRoblox)
+
+return {
+	summary = "",
+	react = React,
+	reactRoblox = ReactRoblox,
+	story = function()
+		return React.createElement("ScrollingFrame", {
+			Size = UDim2.fromScale(1, 1),
+		}, {
+			Label = React.createElement("TextLabel", {
+				Size = UDim2.fromScale(1, 1),
+				AutomaticSize = Enum.AutomaticSize.None,
+
+				TextSize = 24,
+				Text = script.Name,
+				Font = Enum.Font.GothamBold,
+			}),
+		})
+	end,
+}

--- a/src/Components/ScrollingFrame.lua
+++ b/src/Components/ScrollingFrame.lua
@@ -8,7 +8,7 @@ export type Props = {
 	[string]: any,
 }
 
-local function ScrollingFrame(props: Props)
+local ScrollingFrame = React.forwardRef(function(props: Props, ref: any)
 	local theme = useTheme()
 
 	props = Sift.Dictionary.merge({
@@ -22,9 +22,10 @@ local function ScrollingFrame(props: Props)
 		VerticalScrollBarInset = Enum.ScrollBarInset.None,
 		BorderSizePixel = 0,
 		BackgroundTransparency = 1,
+		ref = ref,
 	}, props)
 
 	return React.createElement("ScrollingFrame", props)
-end
+end)
 
 return ScrollingFrame

--- a/src/Components/StoryPreview.lua
+++ b/src/Components/StoryPreview.lua
@@ -6,6 +6,7 @@ local React = require(flipbook.Packages.React)
 local ReactRoblox = require(flipbook.Packages.ReactRoblox)
 local Sift = require(flipbook.Packages.Sift)
 local StoryError = require(flipbook.Components.StoryError)
+local ScrollingFrame = require(flipbook.Components.ScrollingFrame)
 local types = require(script.Parent.Parent.types)
 local mountStory = require(flipbook.Story.mountStory)
 
@@ -63,11 +64,13 @@ local StoryPreview = React.forwardRef(function(props: Props, ref: any)
 				}),
 			}, CoreGui)
 		else
-			return e("Frame", {
-				AutomaticSize = Enum.AutomaticSize.Y,
+			return e(ScrollingFrame, {
 				BackgroundTransparency = 1,
 				LayoutOrder = props.layoutOrder,
-				Size = UDim2.fromScale(1, 0),
+				ScrollingDirection = Enum.ScrollingDirection.XY,
+				AutomaticCanvasSize = Enum.AutomaticSize.XY,
+				CanvasSize = UDim2.new(),
+				Size = UDim2.fromScale(1, 1),
 				ref = ref,
 			}, {
 				Scale = e("UIScale", {

--- a/src/Components/StoryView.lua
+++ b/src/Components/StoryView.lua
@@ -102,6 +102,11 @@ local function StoryView(props: Props)
 				BackgroundTransparency = 1,
 				[React.Change.AbsoluteSize] = onTopbarSizeChanged,
 			}, {
+				Layout = e("UIListLayout", {
+					Padding = theme.paddingLarge,
+					SortOrder = Enum.SortOrder.LayoutOrder,
+				}),
+
 				StoryViewNavbar = e(StoryViewNavbar, {
 					onPreviewInViewport = onPreviewInViewport,
 					onZoomIn = zoom.zoomIn,
@@ -109,23 +114,9 @@ local function StoryView(props: Props)
 					onViewCode = viewCode,
 					onExplorer = exploreStoryParent,
 				}),
-			}),
-
-			ScrollingFrame = e(ScrollingFrame, {
-				LayoutOrder = 2,
-				Size = UDim2.fromScale(1, 1)
-					- UDim2.fromOffset(0, if showControls then controlsHeight else 0)
-					- UDim2.fromOffset(0, topbarHeight),
-			}, {
-				Layout = e("UIListLayout", {
-					Padding = theme.paddingLarge,
-					SortOrder = Enum.SortOrder.LayoutOrder,
-				}),
 
 				Padding = e("UIPadding", {
-					PaddingTop = theme.paddingLarge,
 					PaddingRight = theme.padding,
-					PaddingBottom = theme.padding,
 					PaddingLeft = theme.padding,
 				}),
 
@@ -141,9 +132,23 @@ local function StoryView(props: Props)
 					Size = UDim2.new(1, 0, 0, 1),
 					BorderSizePixel = 0,
 				}),
+			}),
+
+			StoryWrapper = e("Frame", {
+				LayoutOrder = 2,
+				BackgroundTransparency = 1,
+				Size = UDim2.fromScale(1, 1)
+					- UDim2.fromOffset(0, if showControls then controlsHeight else 0)
+					- UDim2.fromOffset(0, topbarHeight),
+			}, {
+				Padding = e("UIPadding", {
+					PaddingTop = theme.paddingLarge,
+					PaddingRight = theme.padding,
+					PaddingBottom = theme.padding,
+					PaddingLeft = theme.padding,
+				}),
 
 				StoryPreview = e(StoryPreview, {
-					layoutOrder = 3,
 					zoom = zoom.value,
 					story = story,
 					controls = controls,


### PR DESCRIPTION
# Problem

The story preview currently does a bad job handling components that use scale-based sizing and components that resize themselves due to our use of AutomaticSize

# Solution

To fix this, the story preview now uses a ScrollingFrame and should now handle several common use cases properly (with tests added for those cases)

Fixes #173

# Checklist

- [x] Ran `./bin/test.sh` locally before merging
