### PR TITLE
Dock at the top

### DIFF
--- a/src/Plugin/createWidget.lua
+++ b/src/Plugin/createWidget.lua
@@ -1,5 +1,5 @@
 local function createWidget(plugin: Plugin, name: string): DockWidgetPluginGui
-	local info = DockWidgetPluginGuiInfo.new(Enum.InitialDockState.Left, true)
+	local info = DockWidgetPluginGuiInfo.new(Enum.InitialDockState.Top, true)
 
 	local widget = plugin:CreateDockWidgetPluginGui(name, info)
 	widget.Name = name


### PR DESCRIPTION
# Problem

It was brought up that flipbook's default docking on the left of the screen means you always have to resize it to the right before it can be usable

# Solution

flipbook now docks at the top by default. You'll still usually have to drag it down (or dock to center) for it to be usable, but this is a more sensible default

# Checklist

- [ ] Ran `./bin/test.sh` locally before merging
