### PR TITLE
Set viewport ScreenGui ZIndexBehavior to `Sibling`

### DIFF
--- a/src/Components/StoryPreview.lua
+++ b/src/Components/StoryPreview.lua
@@ -60,6 +60,7 @@ local StoryPreview = React.forwardRef(function(props: Props, ref: any)
 		if props.isMountedInViewport then
 			return ReactRoblox.createPortal({
 				Story = e("ScreenGui", {
+					ZIndexBehavior = Enum.ZIndexBehavior.Sibling,
 					ref = ref,
 				}),
 			}, CoreGui)


### PR DESCRIPTION
# Problem

When using the "Preview in Viewport" option, the ZIndexBehavior of the resulting ScreenGui is defaulting to `Enum.ZIndexBehavior.Global`. The expected value is `Enum.ZIndexBehavior.Sibling`

# Solution

Simple fix. Added on `Enum.ZIndexBehavior.Sibling` to the viewport ScreenGui

Fixes #200 

# Checklist

- [x] Ran `./bin/test.sh` locally before merging
